### PR TITLE
chore: finish migration cleanup

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -22,7 +22,7 @@ jobs:
   # this main-only lane is the comprehensive backstop.
   mutants:
     runs-on: [self-hosted, linux, x64, drep-mutants]
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       # Keeping target/ makes the 32-thread Strix run take minutes instead of
       # hours. Everything else must still be an exact checkout: unexpected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The persistent runner keeps only `target/` between sweeps and fails closed
   on any other ignored or untracked workspace state. Its dedicated no-login
   account is isolated from user homes and private-network egress, and every
-  external contributor's fork workflow requires maintainer approval.
+  external contributor's fork workflow requires maintainer approval. The job
+  retains a 90-minute stuck-run ceiling, with enough headroom for the measured
+  full sweep to finish when Strix is serving another repository concurrently.
+- Source-file discovery now delegates directly to the allocation-free language
+  registry lookup instead of allocating lowercase and dotted extension strings
+  for every path visited by the repository walk.
 
 ## [2.5.0] - 2026-08-21
 

--- a/tests/release_config.rs
+++ b/tests/release_config.rs
@@ -105,8 +105,8 @@ fn mutation_ci_is_main_only_on_the_pinned_homelab_runner() {
         "the full sweep must require the repository-scoped Strix label"
     );
     assert!(
-        mutants.contains("timeout-minutes: 45"),
-        "a wedged mutation run must release the homelab runner"
+        mutants.contains("timeout-minutes: 90"),
+        "the full sweep needs headroom above its observed runtime while still releasing a wedged runner"
     );
     assert!(
         mutants.contains("tool: cargo-mutants@27.1.0"),


### PR DESCRIPTION
## Summary

- raise the bounded Strix mutation timeout from 45 to 90 minutes after a clean 1,226-mutant sweep collided with the old ceiling during finalisation
- document the allocation-free source discovery improvement already on main
- pin the timeout in the release configuration contract

## Validation

- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features
- cargo fmt --all
- actionlint
- drep lint-docs --fail-on error
- simplify review: reuse, structure, efficiency, and altitude clean

Mutation testing was intentionally skipped for this cleanup-only change at the user's direction.