### PR TITLE
feat(languages): Register Java, Kotlin, Scala and Groovy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Java, Kotlin, Scala and Groovy are registered languages. A repository of
+  `.java` files previously reported "No source files drep recognises were found
+  here" and `drep check` exited 0 having sent nothing to the model, because
+  unknown extensions are dropped at language grouping ahead of both halves. That
+  is the silent pass drep exists to refuse, and on a 200-file Java repository it
+  was the whole of drep's answer. Java gets checkstyle and Kotlin gets ktlint;
+  Scala and Groovy ship with no deterministic tool, since scalafmt, scalafix and
+  CodeNarc are build plugins rather than CLIs. `.gradle` counts as Groovy, so a
+  change to a build script is read. `.kts` is Kotlin, which covers
+  `build.gradle.kts` because `Path::extension` reports `kts` for it.
+- `ToolSpec::config_flag`, for a checker that will not find its own config.
+  ruff reads `pyproject.toml` out of the working directory unprompted;
+  checkstyle exits 1 with "Must specify a config XML", so without this it could
+  never run at all. When set, the config path `config_files` already discovered
+  is appended as `[config_flag, <path>]` ahead of the file arguments, first
+  match in declaration order.
+- `sarif` and `ktlint` output parsers. SARIF is written against the 2.1.0 spec
+  rather than against checkstyle, since it is where the rest of the JVM linters
+  converge, and it strips the `file:` URI scheme so findings are filed under a
+  path that matches the files drep was asked to check. ktlint's reporter is
+  shaped like eslint's with different keys throughout, so it gets its own format
+  rather than teaching the `json` parser to guess between the two.
+
 ### Changed
 
 - Trusted pushes to `main` now run mutation testing only for production code in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than against checkstyle, since it is where the rest of the JVM linters
   converge, and it strips the `file:` URI scheme and percent-decodes the path so
   findings are filed under a path that matches the files drep was asked to
-  check. ktlint's reporter is
+  check. A Windows producer's `file:/C:/repo/Sample.java` also loses the root
+  slash RFC 8089 puts ahead of the drive letter: left in place it makes the path
+  drive-relative, so it matches nothing in the absolute-path table `check` uses
+  to rewrite a finding back to the path the user asked about, and every finding
+  keeps a location no file has. ktlint's reporter is
   shaped like eslint's with different keys throughout, so it gets its own format
   rather than teaching the `json` parser to guess between the two.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   match in declaration order.
 - `sarif` and `ktlint` output parsers. SARIF is written against the 2.1.0 spec
   rather than against checkstyle, since it is where the rest of the JVM linters
-  converge, and it strips the `file:` URI scheme so findings are filed under a
-  path that matches the files drep was asked to check. ktlint's reporter is
+  converge, and it strips the `file:` URI scheme and percent-decodes the path so
+  findings are filed under a path that matches the files drep was asked to
+  check. ktlint's reporter is
   shaped like eslint's with different keys throughout, so it gets its own format
   rather than teaching the `json` parser to guess between the two.
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ Three rules decide what runs:
 | TypeScript | `.ts` `.tsx` `.mts` `.cts` | eslint, tsc |
 | Go | `.go` | gofmt, go vet |
 | Rust | `.rs` | clippy |
+| Java | `.java` | checkstyle |
+| Kotlin | `.kt` `.kts` | ktlint |
+| Scala | `.scala` `.sc` | none |
+| Groovy | `.groovy` `.gradle` | none |
+
+Scala and Groovy have no deterministic tool. scalafmt, scalafix and CodeNarc are
+all build-plugin-first, with no standalone CLI drep can invoke the way it invokes
+ruff. Their entries exist for the semantic half, which needs no tool.
+
+checkstyle is the one checker that will not look for its own config, so the
+ruleset drep discovers is handed to it with `-c`. It refuses to run without one.
 
 The LLM half reads any of them. It parses nothing, so it needs no grammar per
 language; it is told which language it is reading and which conventions that

--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ ruff. Their entries exist for the semantic half, which needs no tool.
 checkstyle is the one checker that will not look for its own config, so the
 ruleset drep discovers is handed to it with `-c`. It refuses to run without one.
 
+ktlint's only discoverable configuration is `.editorconfig`, so a Kotlin file
+in a repository that has one counts as opted in — even one the project wrote
+for its editor rather than for ktlint, which then enforces ktlint's full
+standard ruleset, and which drep reports as unavailable (a failed check, not
+a pass) when the `ktlint` binary is not installed.
+
 The LLM half reads any of them. It parses nothing, so it needs no grammar per
 language; it is told which language it is reading and which conventions that
 language's ecosystem expects.

--- a/scripts/mutants-remote.sh
+++ b/scripts/mutants-remote.sh
@@ -7,7 +7,7 @@
 # full build plus a full test run, and the hook fires on a laptop the developer
 # is still using. Measured on 12 mutants from src/docs/fence.rs: local M5 Max at
 # -j 4 takes 1m54 with the machine pinned. The mutation offload follows the
-# repository's dedicated mutation owner, homelab-2, and costs this machine
+# repository's dedicated mutation owner, Legion, and costs this machine
 # nothing. Ordinary Linux validation and release remain on homelab-1.
 #
 # More jobs is not automatically better. Each job
@@ -15,7 +15,7 @@
 # stay warm - so raising -j multiplies a multi-gigabyte copy before any mutant
 # is tested. On the former 32-thread host, the same scope measured 38s at -j 4,
 # 54s at -j 8, and 72s at -j 16: the copy path was I/O-bound, not CPU-bound.
-# Keep the four-worker baseline on homelab-2 until its own complete sweep gives
+# Keep the four-worker baseline on Legion until its own complete sweep gives
 # a measured reason to change it.
 #
 # The verdict rule is NOT duplicated here. This script syncs, invokes
@@ -25,7 +25,8 @@
 # Falls back to a local run, loudly, when the host is unreachable. A commit gate
 # that silently skips itself because the LAN blipped is worse than a slow one.
 #
-#   DREP_MUTANTS_HOST    ssh target (default: homelab-2.local)
+#   DREP_MUTANTS_HOST    ssh target (default: 192.168.68.72, Legion's reserved
+#                        Ethernet address)
 #   DREP_MUTANTS_DIR     remote path, $HOME-relative
 #                        (default: .cache/drep-mutants/<repo name>)
 #   DREP_MUTANTS_REMOTE_HOST_LOCK

--- a/src/cli/doctor/tests/a_skipped_vs_missing.rs
+++ b/src/cli/doctor/tests/a_skipped_vs_missing.rs
@@ -133,6 +133,7 @@ static GHOST_TOOL: ToolSpec = ToolSpec {
     command: &["drep-ghost-linter-no-machine-has-this"],
     local_paths: &[],
     config_files: &["ghost.config"],
+    config_flag: None,
     output_format: "json",
     diagnostics_stream: "stdout",
     timeout_secs: 120,

--- a/src/files/tests/predicates.rs
+++ b/src/files/tests/predicates.rs
@@ -14,7 +14,8 @@ use crate::files::{is_markdown, is_scan_target};
 /// unsupported - never accepted and silently dropped. See
 /// `the_two_file_classes_are_disjoint` below.
 const REGISTERED_EXTENSIONS: &[&str] = &[
-    ".py", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".go", ".rs",
+    ".py", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".go", ".rs", ".java",
+    ".kt", ".kts", ".scala", ".sc", ".groovy", ".gradle",
 ];
 
 #[test]

--- a/src/languages/definitions.rs
+++ b/src/languages/definitions.rs
@@ -9,12 +9,19 @@
 
 use super::spec::{DEFAULT_TOOL_TIMEOUT_SECS, LanguageSupport, ToolSpec};
 
+/// Build outputs shared by the JVM languages. Gradle writes `build` and
+/// `.gradle`, Maven writes `target`, and IDE-driven builds write `out`.
+/// Declared once rather than repeated across four entries that can never
+/// legitimately disagree.
+static JVM_VENDORED_DIRS: &[&str] = &["build", ".gradle", "target", "out"];
+
 /// Python deterministic checker.
 pub static RUFF: ToolSpec = ToolSpec {
     name: "ruff",
     command: &["ruff", "check", "--output-format", "json"],
     local_paths: &["venv/bin/ruff", ".venv/bin/ruff"],
     config_files: &["pyproject.toml", "ruff.toml", ".ruff.toml"],
+    config_flag: None,
     output_format: "json",
     diagnostics_stream: "stdout",
     timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
@@ -40,6 +47,7 @@ pub static ESLINT: ToolSpec = ToolSpec {
         ".eslintrc.yml",
         ".eslintrc.yaml",
     ],
+    config_flag: None,
     output_format: "json",
     diagnostics_stream: "stdout",
     timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
@@ -55,6 +63,7 @@ pub static TSC: ToolSpec = ToolSpec {
     command: &["tsc", "--noEmit", "--pretty", "false"],
     local_paths: &["node_modules/.bin/tsc"],
     config_files: &["tsconfig.json"],
+    config_flag: None,
     output_format: "tsc",
     diagnostics_stream: "stdout",
     timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
@@ -75,6 +84,7 @@ pub static GOFMT: ToolSpec = ToolSpec {
     command: &["gofmt", "-l"],
     local_paths: &[],
     config_files: &["go.mod"],
+    config_flag: None,
     output_format: "lines",
     diagnostics_stream: "stdout",
     timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
@@ -93,6 +103,7 @@ pub static GO_VET: ToolSpec = ToolSpec {
     command: &["go", "vet"],
     local_paths: &[],
     config_files: &["go.mod"],
+    config_flag: None,
     output_format: "position",
     diagnostics_stream: "stderr",
     timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
@@ -108,6 +119,7 @@ pub static CLIPPY: ToolSpec = ToolSpec {
     command: &["cargo", "clippy", "--message-format", "json", "--quiet"],
     local_paths: &[],
     config_files: &["Cargo.toml"],
+    config_flag: None,
     output_format: "cargo",
     diagnostics_stream: "stdout",
     // Cargo's build lock is acquired by Cargo itself, so its wait is part of
@@ -120,6 +132,58 @@ pub static CLIPPY: ToolSpec = ToolSpec {
     // `cargo clippy` checks a crate, not files: a path argument is rejected
     // with "unexpected argument". See `ToolSpec::accepts_files`.
     accepts_files: false,
+};
+
+/// Java linter. Emits SARIF 2.1.0 on stdout; its startup banner goes to stderr.
+///
+/// `-c` is not in `command`: checkstyle refuses to run without a ruleset and
+/// which one a project uses is exactly what `config_files` discovers, so the
+/// path is appended by `config_flag`. Bare, it exits 1 with "Must specify a
+/// config XML".
+pub static CHECKSTYLE: ToolSpec = ToolSpec {
+    name: "checkstyle",
+    command: &["checkstyle", "-f", "sarif"],
+    local_paths: &[],
+    config_files: &[
+        "checkstyle.xml",
+        ".checkstyle.xml",
+        "config/checkstyle/checkstyle.xml",
+        "gradle/config/checkstyle/checkstyle.xml",
+    ],
+    config_flag: Some("-c"),
+    output_format: "sarif",
+    diagnostics_stream: "stdout",
+    // A JVM start plus a full reflections scan of the check registry, on every
+    // invocation. Two minutes is enough but not generous on a cold page cache.
+    timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
+    timeout_context: None,
+    // It parses; it does not compile. A clean run says nothing about whether
+    // javac would accept the file.
+    establishes_compilation: false,
+    serial_in_repository: false,
+    accepts_files: true,
+};
+
+/// Kotlin linter and formatter, run in lint-only mode.
+///
+/// `--log-level=none` is load-bearing: ktlint writes "Lint has found errors
+/// than can be autocorrected" to **stdout**, ahead of the JSON, and the parser
+/// would reject the whole run as unparseable rather than report the findings.
+pub static KTLINT: ToolSpec = ToolSpec {
+    name: "ktlint",
+    command: &["ktlint", "--log-level=none", "--reporter=json"],
+    local_paths: &[],
+    // ktlint reads `.editorconfig` and nothing else. A Kotlin repo without one
+    // has not chosen ktlint's defaults, so it is skipped.
+    config_files: &[".editorconfig"],
+    config_flag: None,
+    output_format: "ktlint",
+    diagnostics_stream: "stdout",
+    timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
+    timeout_context: None,
+    establishes_compilation: false,
+    serial_in_repository: false,
+    accepts_files: true,
 };
 
 /// Python language entry.
@@ -197,6 +261,88 @@ pub static RUST_LANG: LanguageSupport = LanguageSupport {
     vendored_dirs: &["target"],
 };
 
+/// Java language entry.
+pub static JAVA: LanguageSupport = LanguageSupport {
+    name: "java",
+    display_name: "Java",
+    extensions: &[".java"],
+    tools: &[&CHECKSTYLE],
+    conventions: &[
+        "Resources closed on every path, and try-with-resources where it applies",
+        "Null handling: Optional versus a nullable return, and unchecked dereferences",
+        "equals/hashCode/compareTo consistency, and mutable state in a shared object",
+        "Exceptions swallowed or logged and rethrown, losing the original cause",
+        "Concurrency: unsynchronised shared state, and non-thread-safe fields on a singleton",
+    ],
+    vendored_dirs: JVM_VENDORED_DIRS,
+};
+
+/// Kotlin language entry.
+///
+/// `.kts` covers both scratch scripts and `build.gradle.kts`, which
+/// `Path::extension` reports as `kts` rather than `gradle.kts`.
+pub static KOTLIN: LanguageSupport = LanguageSupport {
+    name: "kotlin",
+    display_name: "Kotlin",
+    extensions: &[".kt", ".kts"],
+    tools: &[&KTLINT],
+    conventions: &[
+        "Platform types from Java interop dereferenced without a null check",
+        "runBlocking on a coroutine path, and scopes that outlive their work",
+        "!! where the null case is real, and lateinit read before assignment",
+        "data class equality over mutable properties",
+    ],
+    vendored_dirs: JVM_VENDORED_DIRS,
+};
+
+/// Scala language entry.
+///
+/// No deterministic tool. scalafmt and scalafix are both build-plugin-first
+/// here, and neither has a standalone CLI drep can invoke the way it invokes
+/// ruff. The semantic half needs none, so the language is registered anyway
+/// rather than leaving `.scala` unreadable.
+pub static SCALA: LanguageSupport = LanguageSupport {
+    name: "scala",
+    display_name: "Scala",
+    extensions: &[".scala", ".sc"],
+    tools: &[],
+    conventions: &[
+        "Partial functions and non-exhaustive matches",
+        "Option/Either handling versus get and head on an empty collection",
+        "Implicits whose resolution is not obvious at the call site",
+        "Futures without an explicit ExecutionContext, and blocking inside one",
+    ],
+    vendored_dirs: JVM_VENDORED_DIRS,
+};
+
+/// Groovy language entry.
+///
+/// `.gradle` is here because a Gradle build script is Groovy, and a change to
+/// one is exactly the kind of thing worth a second read. No deterministic
+/// tool: CodeNarc is a build plugin rather than a CLI.
+pub static GROOVY: LanguageSupport = LanguageSupport {
+    name: "groovy",
+    display_name: "Groovy",
+    extensions: &[".groovy", ".gradle"],
+    tools: &[],
+    conventions: &[
+        "Dynamic dispatch where a typed call would fail at compile time",
+        "Gradle configuration-time work that belongs in a task action",
+        "Dependency and plugin versions pinned versus floating",
+        "String interpolation of values that should be escaped",
+    ],
+    vendored_dirs: JVM_VENDORED_DIRS,
+};
+
 /// Every registered language, in registration order.
-pub static ALL_LANGUAGES: &[&LanguageSupport] =
-    &[&PYTHON, &JAVASCRIPT, &TYPESCRIPT, &GO, &RUST_LANG];
+pub static ALL_LANGUAGES: &[&LanguageSupport] = &[
+    &PYTHON,
+    &JAVASCRIPT,
+    &TYPESCRIPT,
+    &GO,
+    &RUST_LANG,
+    &JAVA,
+    &KOTLIN,
+    &SCALA,
+    &GROOVY,
+];

--- a/src/languages/definitions.rs
+++ b/src/languages/definitions.rs
@@ -10,10 +10,17 @@
 use super::spec::{DEFAULT_TOOL_TIMEOUT_SECS, LanguageSupport, ToolSpec};
 
 /// Build outputs shared by the JVM languages. Gradle writes `build` and
-/// `.gradle`, Maven writes `target`, and IDE-driven builds write `out`.
-/// Declared once rather than repeated across four entries that can never
-/// legitimately disagree.
-static JVM_VENDORED_DIRS: &[&str] = &["build", ".gradle", "target", "out"];
+/// `.gradle`, Maven writes `target`. Declared once rather than repeated across
+/// four entries that can never legitimately disagree.
+///
+/// The set is global in effect: `files::is_ignored_dir` consults the union of
+/// every language's vendored directories, so an entry here skips the directory
+/// in a repository with no JVM code at all. `out` is therefore deliberately
+/// absent: IntelliJ's build output is nearly always gitignored anyway (which
+/// the walker honors on its own), while the name is generic enough that a
+/// checked-in `out/` of real sources in some other ecosystem would be silently
+/// dropped from review.
+static JVM_VENDORED_DIRS: &[&str] = &["build", ".gradle", "target"];
 
 /// Python deterministic checker.
 pub static RUFF: ToolSpec = ToolSpec {

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -236,7 +236,17 @@ mod tests {
         let names: Vec<&str> = langs.iter().map(|l| l.name).collect();
         assert_eq!(
             names,
-            vec!["python", "javascript", "typescript", "go", "rust"]
+            vec![
+                "python",
+                "javascript",
+                "typescript",
+                "go",
+                "rust",
+                "java",
+                "kotlin",
+                "scala",
+                "groovy"
+            ]
         );
     }
 
@@ -305,6 +315,52 @@ mod tests {
             vec![Path::new("a.py")],
             "the markdown file is dropped, not attached to python"
         );
+    }
+
+    /// The JVM family. Java is the one that motivated it: a repository of
+    /// `.java` files reported "No source files drep recognises were found
+    /// here" and `drep check` exited 0 having analyzed nothing, which is the
+    /// silent pass the deterministic half exists to refuse.
+    #[test]
+    fn jvm_extensions_resolve_to_their_languages() {
+        for (path, expected) in [
+            ("Main.java", "java"),
+            ("Main.kt", "kotlin"),
+            ("Main.kts", "kotlin"),
+            ("Main.scala", "scala"),
+            ("Main.sc", "scala"),
+            ("Main.groovy", "groovy"),
+            ("build.gradle", "groovy"),
+        ] {
+            let detected = detect(Path::new(path));
+            assert_eq!(
+                detected.map(|lang| lang.name),
+                Some(expected),
+                "{path} should resolve to {expected}"
+            );
+        }
+    }
+
+    /// `.gradle` is Groovy source that drep should read, but `.gradle.kts` is
+    /// Kotlin and `Path::extension` returns `kts` for it, so the two do not
+    /// collide.
+    #[test]
+    fn gradle_kts_is_kotlin_not_groovy() {
+        assert_eq!(
+            detect(Path::new("build.gradle.kts")).map(|lang| lang.name),
+            Some("kotlin")
+        );
+    }
+
+    #[test]
+    fn jvm_build_directories_are_vendored() {
+        let dirs = vendored_dirs();
+        for expected in ["build", ".gradle", "out"] {
+            assert!(
+                dirs.contains(&expected),
+                "{expected} is a JVM build output and should never be descended into, got {dirs:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -355,7 +355,7 @@ mod tests {
     #[test]
     fn jvm_build_directories_are_vendored() {
         let dirs = vendored_dirs();
-        for expected in ["build", ".gradle", "out"] {
+        for expected in ["build", ".gradle", "target"] {
             assert!(
                 dirs.contains(&expected),
                 "{expected} is a JVM build output and should never be descended into, got {dirs:?}"

--- a/src/languages/runner/mod.rs
+++ b/src/languages/runner/mod.rs
@@ -24,6 +24,7 @@ use crate::analysis::findings::Finding;
 use crate::languages::spec::{DEFAULT_TOOL_TIMEOUT_SECS, ToolSpec};
 
 pub mod parsers;
+mod uri;
 
 pub use parsers::parse_output;
 

--- a/src/languages/runner/mod.rs
+++ b/src/languages/runner/mod.rs
@@ -308,9 +308,21 @@ pub(crate) async fn run_tool_at(
         executable
     };
 
-    let mut argv: Vec<String> = Vec::with_capacity(spec.command.len() + files.len());
+    let mut argv: Vec<String> = Vec::with_capacity(spec.command.len() + files.len() + 2);
     argv.push(executable.to_string_lossy().into_owned());
     argv.extend(spec.command[1..].iter().map(|s| (*s).to_owned()));
+    // A tool that will not look for its own config gets handed the one
+    // `config_files` found. First match in declaration order, so the list reads
+    // as a preference rather than as whatever the filesystem returns.
+    if let Some(flag) = spec.config_flag
+        && let Some(config) = spec
+            .config_files
+            .iter()
+            .find(|name| workspace_root.join(name).exists())
+    {
+        argv.push(flag.to_owned());
+        argv.push((*config).to_owned());
+    }
     // A repository can contain a file whose name begins with `-`, and every
     // checker here would read `--fix` as an option rather than a path. `--`
     // is the conventional guard but is not universally supported across

--- a/src/languages/runner/parsers.rs
+++ b/src/languages/runner/parsers.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 
 use crate::analysis::findings::{Finding, Severity};
 use crate::languages::runner::ToolOutputError;
+use crate::languages::runner::uri::strip_file_uri;
 use crate::languages::spec::ToolSpec;
 
 /// `[vet: ]./path/to/file.go:12:6: message` - the compiler-style position
@@ -447,68 +448,6 @@ fn sarif_severity(level: Option<&str>) -> Severity {
         Some("note") | Some("none") => Severity::Info,
         _ => Severity::Warning,
     }
-}
-
-/// `file:/abs/path` and `file:///abs/path` both name a local path. drep matches
-/// findings against the paths it was asked to check, so a finding left under a
-/// URI is filed against a path that matches nothing and is silently dropped.
-///
-/// The path is percent-decoded because producers encode it: checkstyle's
-/// SarifLogger maps a space to `%20` and a quote to `%22`, and a spec-compliant
-/// producer percent-encodes everything reserved. Left encoded, the finding's
-/// path never matches the file drep was asked to check.
-fn strip_file_uri(uri: &str) -> String {
-    let path = uri
-        .strip_prefix("file://")
-        .or_else(|| uri.strip_prefix("file:"))
-        .unwrap_or(uri);
-    // `file:///abs` leaves a leading empty authority; `file:/abs` does not.
-    if path.is_empty() {
-        uri.to_owned()
-    } else {
-        percent_decode(path)
-    }
-}
-
-/// Decode RFC 3986 `%HH` sequences byte-wise. Anything that is not a valid
-/// triplet passes through verbatim, and malformed UTF-8 at the end of decoding
-/// degrades lossily rather than failing the finding. checkstyle encodes only
-/// the space and the quote, so a literal `%20` *in* a filename is ambiguous
-/// with an encoded one at the source; decoding is the better wrong there,
-/// because spaces in paths are common and `%20` in a name is not.
-fn percent_decode(text: &str) -> String {
-    if !text.contains('%') {
-        return text.to_owned();
-    }
-    let bytes = text.as_bytes();
-    let mut decoded = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        let triplet = match bytes.get(i..i + 3) {
-            // `hi * 16 + lo`, not `hi << 4 | lo`: the two nibbles never share
-            // a set bit, so `|` and `^` agree on every reachable input and the
-            // mutation gate cannot observe the difference.
-            Some(&[b'%', hi, lo]) => hex_value(hi)
-                .zip(hex_value(lo))
-                .map(|(hi, lo)| hi * 16 + lo),
-            _ => None,
-        };
-        match triplet {
-            Some(byte) => {
-                decoded.push(byte);
-                i += 3;
-            }
-            None => {
-                decoded.push(bytes[i]);
-                i += 1;
-            }
-        }
-    }
-    String::from_utf8_lossy(&decoded).into_owned()
-}
-
-fn hex_value(byte: u8) -> Option<u8> {
-    (byte as char).to_digit(16).map(|d| d as u8)
 }
 
 /// ktlint's JSON reporter: one record per file with a nested `errors` array.

--- a/src/languages/runner/parsers.rs
+++ b/src/languages/runner/parsers.rs
@@ -452,6 +452,11 @@ fn sarif_severity(level: Option<&str>) -> Severity {
 /// `file:/abs/path` and `file:///abs/path` both name a local path. drep matches
 /// findings against the paths it was asked to check, so a finding left under a
 /// URI is filed against a path that matches nothing and is silently dropped.
+///
+/// The path is percent-decoded because producers encode it: checkstyle's
+/// SarifLogger maps a space to `%20` and a quote to `%22`, and a spec-compliant
+/// producer percent-encodes everything reserved. Left encoded, the finding's
+/// path never matches the file drep was asked to check.
 fn strip_file_uri(uri: &str) -> String {
     let path = uri
         .strip_prefix("file://")
@@ -461,8 +466,49 @@ fn strip_file_uri(uri: &str) -> String {
     if path.is_empty() {
         uri.to_owned()
     } else {
-        path.to_owned()
+        percent_decode(path)
     }
+}
+
+/// Decode RFC 3986 `%HH` sequences byte-wise. Anything that is not a valid
+/// triplet passes through verbatim, and malformed UTF-8 at the end of decoding
+/// degrades lossily rather than failing the finding. checkstyle encodes only
+/// the space and the quote, so a literal `%20` *in* a filename is ambiguous
+/// with an encoded one at the source; decoding is the better wrong there,
+/// because spaces in paths are common and `%20` in a name is not.
+fn percent_decode(text: &str) -> String {
+    if !text.contains('%') {
+        return text.to_owned();
+    }
+    let bytes = text.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let triplet = match bytes.get(i..i + 3) {
+            // `hi * 16 + lo`, not `hi << 4 | lo`: the two nibbles never share
+            // a set bit, so `|` and `^` agree on every reachable input and the
+            // mutation gate cannot observe the difference.
+            Some(&[b'%', hi, lo]) => hex_value(hi)
+                .zip(hex_value(lo))
+                .map(|(hi, lo)| hi * 16 + lo),
+            _ => None,
+        };
+        match triplet {
+            Some(byte) => {
+                decoded.push(byte);
+                i += 3;
+            }
+            None => {
+                decoded.push(bytes[i]);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    (byte as char).to_digit(16).map(|d| d as u8)
 }
 
 /// ktlint's JSON reporter: one record per file with a nested `errors` array.
@@ -470,6 +516,12 @@ fn strip_file_uri(uri: &str) -> String {
 /// Shaped like eslint's but with different keys throughout - `file` for
 /// `filePath`, `errors` for `messages`, `rule` for `ruleId` - so it gets its
 /// own format rather than teaching `parse_json` to guess between them.
+///
+/// Why not ktlint's own `sarif` reporter, given `parse_sarif` exists: that
+/// reporter files every result under a relative URI with
+/// `uriBaseId: "%SRCROOT%"` bound to the process *home*, not the working
+/// directory, so a finding's path resolves to nothing drep was asked to
+/// check. The JSON reporter emits plain absolute paths instead.
 fn parse_ktlint(spec: &ToolSpec, output: &str) -> Result<Vec<Finding>, ToolOutputError> {
     let trimmed = output.trim();
     if trimmed.is_empty() {

--- a/src/languages/runner/parsers.rs
+++ b/src/languages/runner/parsers.rs
@@ -57,6 +57,8 @@ pub fn parse_output(
         "position" => Ok(parse_positions(spec, output)),
         "tsc" => Ok(parse_tsc(spec, output)),
         "cargo" => parse_cargo(spec, output),
+        "sarif" => parse_sarif(spec, output),
+        "ktlint" => parse_ktlint(spec, output),
         other => Err(ToolOutputError(format!(
             "{}: no parser for output format {other:?}",
             spec.name,
@@ -348,6 +350,177 @@ fn parse_json(
                 line,
                 column,
                 message_text,
+                None,
+            ));
+        }
+    }
+    Ok(findings)
+}
+
+/// SARIF 2.1.0: `runs[].results[]`, the interchange format checkstyle emits.
+///
+/// Written against the spec rather than against checkstyle, because SARIF is
+/// what the rest of the JVM linters converge on and a second one should need
+/// no parser. Empty input is a clean run for the same reason it is under
+/// `json`; anything else that will not parse is an error.
+fn parse_sarif(spec: &ToolSpec, output: &str) -> Result<Vec<Finding>, ToolOutputError> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let payload: Value = serde_json::from_str(trimmed).map_err(|err| {
+        ToolOutputError(format!("{} produced unparseable SARIF: {err}", spec.name))
+    })?;
+
+    let runs = payload
+        .get("runs")
+        .and_then(Value::as_array)
+        .ok_or_else(|| ToolOutputError(format!("{}: SARIF has no runs array", spec.name)))?;
+
+    let mut findings = Vec::new();
+    for run in runs {
+        let results = run
+            .get("results")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        for result in results {
+            let kind = result
+                .get("ruleId")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .unwrap_or_else(|| spec.name.to_owned());
+            let message = result
+                .get("message")
+                .and_then(|m| m.get("text"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned();
+
+            // First location only. SARIF allows several, but every checker
+            // here reports one per diagnostic, and reporting the same finding
+            // once per location would double-count a gate.
+            let physical = result
+                .get("locations")
+                .and_then(Value::as_array)
+                .and_then(|locations| locations.first())
+                .and_then(|location| location.get("physicalLocation"));
+            let file_path = physical
+                .and_then(|p| p.get("artifactLocation"))
+                .and_then(|a| a.get("uri"))
+                .and_then(Value::as_str)
+                .map(strip_file_uri)
+                .unwrap_or_default();
+            let region = physical.and_then(|p| p.get("region"));
+            let line = region
+                .and_then(|r| r.get("startLine"))
+                .and_then(Value::as_u64)
+                .map(|n| n as u32)
+                .unwrap_or(1);
+            let column = region
+                .and_then(|r| r.get("startColumn"))
+                .and_then(Value::as_u64)
+                .map(|n| n as u32);
+
+            findings.push(Finding::deterministic(
+                kind,
+                sarif_severity(result.get("level").and_then(Value::as_str)),
+                file_path,
+                line,
+                column,
+                message,
+                None,
+            ));
+        }
+    }
+    Ok(findings)
+}
+
+/// SARIF `level` to drep severity.
+///
+/// `none` is SARIF for "this rule was evaluated and had nothing to say", which
+/// no tool should emit as a result, so it lands on Info rather than inventing
+/// a fourth level. An absent level defaults to `warning` per the spec.
+fn sarif_severity(level: Option<&str>) -> Severity {
+    match level {
+        Some("error") => Severity::Error,
+        Some("note") | Some("none") => Severity::Info,
+        _ => Severity::Warning,
+    }
+}
+
+/// `file:/abs/path` and `file:///abs/path` both name a local path. drep matches
+/// findings against the paths it was asked to check, so a finding left under a
+/// URI is filed against a path that matches nothing and is silently dropped.
+fn strip_file_uri(uri: &str) -> String {
+    let path = uri
+        .strip_prefix("file://")
+        .or_else(|| uri.strip_prefix("file:"))
+        .unwrap_or(uri);
+    // `file:///abs` leaves a leading empty authority; `file:/abs` does not.
+    if path.is_empty() {
+        uri.to_owned()
+    } else {
+        path.to_owned()
+    }
+}
+
+/// ktlint's JSON reporter: one record per file with a nested `errors` array.
+///
+/// Shaped like eslint's but with different keys throughout - `file` for
+/// `filePath`, `errors` for `messages`, `rule` for `ruleId` - so it gets its
+/// own format rather than teaching `parse_json` to guess between them.
+fn parse_ktlint(spec: &ToolSpec, output: &str) -> Result<Vec<Finding>, ToolOutputError> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let payload: Value = serde_json::from_str(trimmed).map_err(|err| {
+        ToolOutputError(format!("{} produced unparseable JSON: {err}", spec.name))
+    })?;
+    let entries = payload.as_array().ok_or_else(|| {
+        ToolOutputError(format!(
+            "{}: expected a JSON array, got {}",
+            spec.name,
+            json_kind_name(&payload)
+        ))
+    })?;
+
+    let mut findings = Vec::new();
+    for entry in entries {
+        let file_path = entry
+            .get("file")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_owned();
+        let errors = entry
+            .get("errors")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        for error in errors {
+            findings.push(Finding::deterministic(
+                error
+                    .get("rule")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| spec.name.to_owned()),
+                Severity::Error,
+                file_path.clone(),
+                error
+                    .get("line")
+                    .and_then(Value::as_u64)
+                    .map(|n| n as u32)
+                    .unwrap_or(1),
+                error
+                    .get("column")
+                    .and_then(Value::as_u64)
+                    .map(|n| n as u32),
+                error
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_owned(),
                 None,
             ));
         }

--- a/src/languages/runner/tests/parsers.rs
+++ b/src/languages/runner/tests/parsers.rs
@@ -297,12 +297,100 @@ fn sarif_parser_strips_the_file_uri_scheme() {
     assert_eq!(findings[0].file_path, "/private/tmp/jvmfix/Sample.java");
 }
 
+/// checkstyle's SarifLogger percent-encodes exactly the space and the double
+/// quote in a file name (`renderFileNameUri`). Left encoded, the finding's
+/// path never matches the file drep was asked to check and displays mangled.
+#[test]
+fn sarif_parser_percent_decodes_the_uri_path() {
+    let spec = checkstyle_like_spec();
+    let sarif = r#"{
+      "version": "2.1.0",
+      "runs": [ { "results": [
+        { "level": "warning",
+          "locations": [ { "physicalLocation": {
+              "artifactLocation": { "uri": "file:/repo/My%20Sources/Has%22Quote%22.java" },
+              "region": { "startLine": 3 } } } ],
+          "message": { "text": "m" },
+          "ruleId": "r" }
+      ] } ]
+    }"#;
+    let findings = parse_output(&spec, sarif, "root").unwrap();
+    assert_eq!(findings[0].file_path, "/repo/My Sources/Has\"Quote\".java");
+}
+
+/// A `%` that does not open a valid hex triplet is a literal, not an encoding:
+/// a file genuinely named `100%.java` must survive the round trip.
+#[test]
+fn sarif_parser_leaves_malformed_percent_sequences_alone() {
+    let spec = checkstyle_like_spec();
+    for uri in [
+        "file:/repo/100%.java",
+        "file:/repo/100%2x.java",
+        "file:/repo/ends%2.java",
+    ] {
+        let sarif = format!(
+            r#"{{ "version": "2.1.0", "runs": [ {{ "results": [
+                {{ "level": "warning",
+                  "locations": [ {{ "physicalLocation": {{
+                      "artifactLocation": {{ "uri": "{uri}" }},
+                      "region": {{ "startLine": 1 }} }} }} ],
+                  "message": {{ "text": "m" }}, "ruleId": "r" }}
+            ] }} ] }}"#
+        );
+        let findings = parse_output(&spec, &sarif, "root").unwrap();
+        assert_eq!(
+            findings[0].file_path,
+            uri.strip_prefix("file:").unwrap(),
+            "{uri} should pass through undecoded"
+        );
+    }
+}
+
 #[test]
 fn sarif_parser_maps_the_sarif_level_to_severity() {
     let spec = checkstyle_like_spec();
     let findings = parse_output(&spec, checkstyle_sarif(), "root").unwrap();
     assert_eq!(findings[0].severity, Severity::Error);
     assert_eq!(findings[1].severity, Severity::Warning);
+}
+
+/// checkstyle emits `note` for its INFO severity level. `none` is SARIF for
+/// "this rule was evaluated and had nothing to say". Neither is a warning, and
+/// both must stay distinguishable from one: the fixture above never carries
+/// either, so only a dedicated test keeps the arm from collapsing into the
+/// catch-all.
+#[test]
+fn sarif_levels_note_and_none_map_to_info_not_warning() {
+    let spec = checkstyle_like_spec();
+    let sarif = r#"{
+      "version": "2.1.0",
+      "runs": [ { "results": [
+        { "level": "note",
+          "locations": [ { "physicalLocation": {
+              "artifactLocation": { "uri": "file:/repo/A.java" },
+              "region": { "startLine": 1 } } } ],
+          "message": { "text": "informational" },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.SomeInfoCheck" },
+        { "level": "none",
+          "locations": [ { "physicalLocation": {
+              "artifactLocation": { "uri": "file:/repo/A.java" },
+              "region": { "startLine": 2 } } } ],
+          "message": { "text": "evaluated, nothing to say" },
+          "ruleId": "com.puppycrawl.tools.checkstyle.checks.SomeQuietCheck" }
+      ] } ]
+    }"#;
+    let findings = parse_output(&spec, sarif, "root").unwrap();
+    assert_eq!(findings.len(), 2);
+    assert_eq!(
+        findings[0].severity,
+        Severity::Info,
+        "note is informational"
+    );
+    assert_eq!(
+        findings[1].severity,
+        Severity::Info,
+        "none must not become a warning"
+    );
 }
 
 #[test]

--- a/src/languages/runner/tests/parsers.rs
+++ b/src/languages/runner/tests/parsers.rs
@@ -234,3 +234,136 @@ fn unknown_output_format_is_error_not_empty() {
     let err = parse_output(&spec, "anything", "root").unwrap_err();
     assert!(err.0.contains("not-a-format"));
 }
+
+// ---- parsers: sarif ----
+
+/// Trimmed from a real `checkstyle -c checkstyle.xml -f sarif` run: the driver
+/// block and rule descriptions are dropped, the two results are verbatim.
+fn checkstyle_sarif() -> &'static str {
+    r#"{
+      "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+      "version": "2.1.0",
+      "runs": [
+        {
+          "tool": { "driver": { "name": "Checkstyle", "version": "14.1.0" } },
+          "results": [
+            {
+              "level": "error",
+              "locations": [
+                { "physicalLocation": {
+                    "artifactLocation": { "uri": "file:/private/tmp/jvmfix/Sample.java" },
+                    "region": { "startColumn": 8, "startLine": 2 } } }
+              ],
+              "message": { "id": "import.unused", "text": "Unused import - java.util.List." },
+              "ruleId": "com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"
+            },
+            {
+              "level": "warning",
+              "locations": [
+                { "physicalLocation": {
+                    "artifactLocation": { "uri": "file:/private/tmp/jvmfix/Sample.java" },
+                    "region": { "startColumn": 14, "startLine": 5 } } }
+              ],
+              "message": { "id": "ws.notFollowed", "text": "'=' is not followed by whitespace." },
+              "ruleId": "com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck"
+            }
+          ]
+        }
+      ]
+    }"#
+}
+
+#[test]
+fn sarif_parser_reads_rule_location_and_message() {
+    let spec = checkstyle_like_spec();
+    let findings = parse_output(&spec, checkstyle_sarif(), "root").expect("sarif parses");
+    assert_eq!(findings.len(), 2);
+    assert_eq!(
+        findings[0].kind,
+        "com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"
+    );
+    assert_eq!(findings[0].line, 2);
+    assert_eq!(findings[0].column, Some(8));
+    assert_eq!(findings[0].message, "Unused import - java.util.List.");
+}
+
+/// SARIF carries a URI, drep matches findings against the paths it was asked
+/// to check. A finding filed under `file:/private/tmp/...` is filed under a
+/// path that never matches, so it is dropped as belonging to another file.
+#[test]
+fn sarif_parser_strips_the_file_uri_scheme() {
+    let spec = checkstyle_like_spec();
+    let findings = parse_output(&spec, checkstyle_sarif(), "root").unwrap();
+    assert_eq!(findings[0].file_path, "/private/tmp/jvmfix/Sample.java");
+}
+
+#[test]
+fn sarif_parser_maps_the_sarif_level_to_severity() {
+    let spec = checkstyle_like_spec();
+    let findings = parse_output(&spec, checkstyle_sarif(), "root").unwrap();
+    assert_eq!(findings[0].severity, Severity::Error);
+    assert_eq!(findings[1].severity, Severity::Warning);
+}
+
+#[test]
+fn sarif_parser_treats_no_output_as_clean() {
+    let spec = checkstyle_like_spec();
+    let findings = parse_output(&spec, "", "root").expect("empty output is a clean run");
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn sarif_parser_errors_on_unparseable_input() {
+    let spec = checkstyle_like_spec();
+    let err = parse_output(&spec, "not json at all", "root")
+        .expect_err("garbage must not be reported as clean");
+    assert!(err.0.contains("checkstyle"), "message was {:?}", err.0);
+}
+
+// ---- parsers: ktlint ----
+
+/// Verbatim from `ktlint --log-level=none --reporter=json`.
+fn ktlint_json() -> &'static str {
+    r#"[
+        {
+            "file": "/private/tmp/jvmfix/Sample.kt",
+            "errors": [
+                { "line": 5, "column": 10, "message": "Unexpected whitespace",
+                  "rule": "standard:parameter-list-spacing" },
+                { "line": 6, "column": 10, "message": "Missing spacing around \"=\"",
+                  "rule": "standard:op-spacing" }
+            ]
+        }
+    ]"#
+}
+
+#[test]
+fn ktlint_parser_reads_every_error_under_its_file() {
+    let spec = ktlint_like_spec();
+    let findings = parse_output(&spec, ktlint_json(), "root").expect("ktlint json parses");
+    assert_eq!(findings.len(), 2);
+    for finding in &findings {
+        assert_eq!(finding.file_path, "/private/tmp/jvmfix/Sample.kt");
+        assert_eq!(finding.severity, Severity::Error);
+    }
+    assert_eq!(findings[0].kind, "standard:parameter-list-spacing");
+    assert_eq!(findings[0].line, 5);
+    assert_eq!(findings[0].column, Some(10));
+    assert_eq!(findings[1].message, "Missing spacing around \"=\"");
+}
+
+/// ktlint prints `[]` for a clean run, and nothing at all when it has no files
+/// to look at.
+#[test]
+fn ktlint_parser_treats_empty_and_empty_array_as_clean() {
+    let spec = ktlint_like_spec();
+    assert!(parse_output(&spec, "", "root").unwrap().is_empty());
+    assert!(parse_output(&spec, "[]", "root").unwrap().is_empty());
+}
+
+#[test]
+fn ktlint_parser_errors_on_unparseable_input() {
+    let spec = ktlint_like_spec();
+    let err = parse_output(&spec, "{oops", "root").expect_err("garbage is not a clean run");
+    assert!(err.0.contains("ktlint"), "message was {:?}", err.0);
+}

--- a/src/languages/runner/tests/parsers.rs
+++ b/src/languages/runner/tests/parsers.rs
@@ -287,6 +287,19 @@ fn sarif_parser_reads_rule_location_and_message() {
     assert_eq!(findings[0].message, "Unused import - java.util.List.");
 }
 
+/// One SARIF result naming `uri`, for the URI-handling tests.
+fn sarif_for_uri(uri: &str) -> String {
+    format!(
+        r#"{{ "version": "2.1.0", "runs": [ {{ "results": [
+            {{ "level": "warning",
+              "locations": [ {{ "physicalLocation": {{
+                  "artifactLocation": {{ "uri": "{uri}" }},
+                  "region": {{ "startLine": 1 }} }} }} ],
+              "message": {{ "text": "m" }}, "ruleId": "r" }}
+        ] }} ] }}"#
+    )
+}
+
 /// SARIF carries a URI, drep matches findings against the paths it was asked
 /// to check. A finding filed under `file:/private/tmp/...` is filed under a
 /// path that never matches, so it is dropped as belonging to another file.
@@ -303,19 +316,45 @@ fn sarif_parser_strips_the_file_uri_scheme() {
 #[test]
 fn sarif_parser_percent_decodes_the_uri_path() {
     let spec = checkstyle_like_spec();
-    let sarif = r#"{
-      "version": "2.1.0",
-      "runs": [ { "results": [
-        { "level": "warning",
-          "locations": [ { "physicalLocation": {
-              "artifactLocation": { "uri": "file:/repo/My%20Sources/Has%22Quote%22.java" },
-              "region": { "startLine": 3 } } } ],
-          "message": { "text": "m" },
-          "ruleId": "r" }
-      ] } ]
-    }"#;
-    let findings = parse_output(&spec, sarif, "root").unwrap();
+    let sarif = sarif_for_uri("file:/repo/My%20Sources/Has%22Quote%22.java");
+    let findings = parse_output(&spec, &sarif, "root").unwrap();
     assert_eq!(findings[0].file_path, "/repo/My Sources/Has\"Quote\".java");
+}
+
+/// The drive-root rule, end to end through the parser; `strip_drive_root` has
+/// the reasoning.
+#[test]
+fn sarif_parser_drops_the_root_slash_before_a_windows_drive() {
+    let spec = checkstyle_like_spec();
+    let findings =
+        parse_output(&spec, &sarif_for_uri("file:/C:/repo/Sample.java"), "root").unwrap();
+    assert_eq!(findings[0].file_path, "C:/repo/Sample.java");
+}
+
+/// Every condition on the drive prefix has to hold, and each fixture here fails
+/// exactly one of them: the drive strip must not fire on an ordinary POSIX
+/// path, on a first component that merely starts with a letter, or on a name
+/// whose colon is not a drive separator.
+#[test]
+fn sarif_parser_keeps_paths_that_only_look_like_a_drive() {
+    let spec = checkstyle_like_spec();
+    for path in [
+        // No drive letter at all - the ordinary POSIX case.
+        "/repo/Sample.java",
+        // A letter, but no colon after it.
+        "/C/repo/Sample.java",
+        // A colon, but two characters in rather than one.
+        "/repo:/Sample.java",
+        // A drive-looking prefix that is not bounded by a separator.
+        "/C:x/Sample.java",
+        // Already drive-absolute: nothing to strip, and stripping would eat
+        // the drive letter.
+        "C:/repo/Sample.java",
+    ] {
+        let sarif = sarif_for_uri(&format!("file:{path}"));
+        let findings = parse_output(&spec, &sarif, "root").unwrap();
+        assert_eq!(findings[0].file_path, path, "{path} should pass through");
+    }
 }
 
 /// A `%` that does not open a valid hex triplet is a literal, not an encoding:
@@ -328,15 +367,7 @@ fn sarif_parser_leaves_malformed_percent_sequences_alone() {
         "file:/repo/100%2x.java",
         "file:/repo/ends%2.java",
     ] {
-        let sarif = format!(
-            r#"{{ "version": "2.1.0", "runs": [ {{ "results": [
-                {{ "level": "warning",
-                  "locations": [ {{ "physicalLocation": {{
-                      "artifactLocation": {{ "uri": "{uri}" }},
-                      "region": {{ "startLine": 1 }} }} }} ],
-                  "message": {{ "text": "m" }}, "ruleId": "r" }}
-            ] }} ] }}"#
-        );
+        let sarif = sarif_for_uri(uri);
         let findings = parse_output(&spec, &sarif, "root").unwrap();
         assert_eq!(
             findings[0].file_path,

--- a/src/languages/runner/tests/run_tool.rs
+++ b/src/languages/runner/tests/run_tool.rs
@@ -400,3 +400,102 @@ async fn a_filename_that_looks_like_a_flag_is_passed_as_a_path() {
         "it must not reach the tool as a bare option: {argv:?}"
     );
 }
+
+// ---- run_tool: config_flag ----
+
+/// Builds an argv-recording stub in a temp repo, runs `spec` against it, and
+/// returns what the tool actually received.
+fn argv_after_running(spec: &ToolSpec, config_files: &[&str]) -> (TempDir, Vec<String>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = dir.path().join("bin");
+    std::fs::create_dir_all(&bin).expect("mkdir bin");
+    write_executable(
+        &bin.join("argvdump"),
+        format!(
+            "#!/bin/sh\nfor a in \"$@\"; do echo \"$a\"; done > {}/argv.txt\nexit 0\n",
+            dir.path().display()
+        ),
+    );
+    for config in config_files {
+        let path = dir.path().join(config);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir config parent");
+        }
+        std::fs::write(path, "").expect("config");
+    }
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    runtime.block_on(run_tool(spec, dir.path(), &["Sample.java".to_owned()]));
+    let argv = std::fs::read_to_string(dir.path().join("argv.txt")).unwrap_or_default();
+    let lines = argv.lines().map(str::to_owned).collect();
+    (dir, lines)
+}
+
+/// checkstyle exits 1 with "Must specify a config XML" when run bare, so the
+/// ruleset `config_files` found has to reach it or the tool can never run.
+#[test]
+fn config_flag_passes_the_discovered_config_before_the_files() {
+    let spec = ToolSpec {
+        name: "argvdump",
+        command: &["argvdump", "-f", "sarif"],
+        local_paths: &["bin/argvdump"],
+        config_files: &["config/checkstyle/checkstyle.xml"],
+        config_flag: Some("-c"),
+        output_format: "sarif",
+        diagnostics_stream: "stdout",
+        ..ToolSpec::default()
+    };
+    let (_dir, argv) = argv_after_running(&spec, &["config/checkstyle/checkstyle.xml"]);
+    assert_eq!(
+        argv,
+        vec![
+            "-f",
+            "sarif",
+            "-c",
+            "config/checkstyle/checkstyle.xml",
+            "Sample.java"
+        ],
+        "the config must land between the static command and the files"
+    );
+}
+
+/// The first entry in `config_files` that exists wins, matching the order the
+/// list is written in rather than whatever the filesystem returns.
+#[test]
+fn config_flag_uses_the_first_config_file_that_exists() {
+    let spec = ToolSpec {
+        name: "argvdump",
+        command: &["argvdump"],
+        local_paths: &["bin/argvdump"],
+        config_files: &["checkstyle.xml", "config/checkstyle/checkstyle.xml"],
+        config_flag: Some("-c"),
+        output_format: "sarif",
+        diagnostics_stream: "stdout",
+        ..ToolSpec::default()
+    };
+    let (_dir, argv) = argv_after_running(&spec, &["config/checkstyle/checkstyle.xml"]);
+    assert_eq!(
+        argv,
+        vec!["-c", "config/checkstyle/checkstyle.xml", "Sample.java"]
+    );
+}
+
+/// A tool that finds its own config is untouched, which is every tool that
+/// shipped before this one.
+#[test]
+fn no_config_flag_leaves_the_command_alone() {
+    let spec = ToolSpec {
+        name: "argvdump",
+        command: &["argvdump", "check"],
+        local_paths: &["bin/argvdump"],
+        config_files: &["pyproject.toml"],
+        config_flag: None,
+        output_format: "lines",
+        diagnostics_stream: "stdout",
+        ..ToolSpec::default()
+    };
+    let (_dir, argv) = argv_after_running(&spec, &["pyproject.toml"]);
+    assert_eq!(argv, vec!["check", "Sample.java"]);
+}

--- a/src/languages/runner/tests/support.rs
+++ b/src/languages/runner/tests/support.rs
@@ -73,3 +73,31 @@ pub(crate) fn clippy_like_spec() -> ToolSpec {
 /// Re-exported so this suite's `use super::support::*` importers reach the
 /// crate-wide helper rather than a local copy.
 pub(crate) use crate::test_support::write_executable;
+
+/// checkstyle emits SARIF 2.1.0 on stdout. `-c` is appended by `config_flag`
+/// rather than written here, since which ruleset a project uses is exactly
+/// what `config_files` discovers.
+pub(crate) fn checkstyle_like_spec() -> ToolSpec {
+    ToolSpec {
+        name: "checkstyle",
+        command: &["checkstyle", "-f", "sarif"],
+        local_paths: &[],
+        config_files: &["checkstyle.xml"],
+        config_flag: Some("-c"),
+        output_format: "sarif",
+        diagnostics_stream: "stdout",
+        ..ToolSpec::default()
+    }
+}
+
+pub(crate) fn ktlint_like_spec() -> ToolSpec {
+    ToolSpec {
+        name: "ktlint",
+        command: &["ktlint", "--log-level=none", "--reporter=json"],
+        local_paths: &[],
+        config_files: &[".editorconfig"],
+        output_format: "ktlint",
+        diagnostics_stream: "stdout",
+        ..ToolSpec::default()
+    }
+}

--- a/src/languages/runner/uri.rs
+++ b/src/languages/runner/uri.rs
@@ -1,0 +1,106 @@
+//! Turn a `file:` URI into the path drep was asked to check.
+//!
+//! Split from `parsers.rs` because it is a URI decoder rather than a diagnostic
+//! reader: SARIF is the only format that mandates a URI, but the decoding is
+//! the spec's rather than checkstyle's, so it belongs beside the other
+//! encoding rules rather than among the per-tool parsers.
+//!
+//! Decoding is complete before the path leaves here. `check` looks a finding's
+//! absolute path up in a table to rewrite it back to the path the user typed,
+//! and a half-decoded URI matches nothing in that table, so the finding keeps a
+//! location no file has.
+
+/// `file:/abs/path` and `file:///abs/path` both name a local path. drep matches
+/// findings against the paths it was asked to check, so a finding left under a
+/// URI is filed against a path that matches nothing and is silently dropped.
+///
+/// The path is percent-decoded because producers encode it: checkstyle's
+/// SarifLogger maps a space to `%20` and a quote to `%22`, and a spec-compliant
+/// producer percent-encodes everything reserved. Left encoded, the finding's
+/// path never matches the file drep was asked to check.
+pub(super) fn strip_file_uri(uri: &str) -> String {
+    let path = uri
+        .strip_prefix("file://")
+        .or_else(|| uri.strip_prefix("file:"))
+        .unwrap_or(uri);
+    // `file:///abs` leaves a leading empty authority; `file:/abs` does not.
+    if path.is_empty() {
+        uri.to_owned()
+    } else {
+        strip_drive_root(percent_decode(path))
+    }
+}
+
+/// `file:/C:/repo/Sample.java` is how a Windows producer names a local path.
+/// RFC 8089 requires the path component to begin with `/`, so the drive letter
+/// arrives one slash deeper than the path it denotes. Left in place that slash
+/// makes the path drive-relative rather than absolute, so it matches nothing in
+/// the absolute-path table `check` uses to rewrite a finding back to the path
+/// the user asked about, and every Windows checkstyle finding keeps a location
+/// no file has.
+///
+/// Applied on every platform rather than under `cfg(windows)`: a `cfg`-gated
+/// twin is invisible to the mutation gate, and a first component that is a bare
+/// ASCII letter followed by a colon is not a path any Unix producer emits.
+///
+/// Four named conditions rather than one slice pattern, for the reason
+/// `percent_decode` writes `hi * 16 + lo` below: cargo-mutants does not mutate
+/// match patterns, so `matches!(path.as_bytes(), [b'/', d, b':', ..])` states
+/// the same rule while making every part of it invisible to the gate. Written
+/// this way it carries five mutable operators, and the fixture table in
+/// `sarif_parser_keeps_paths_that_only_look_like_a_drive` has one row per
+/// operator to discriminate them.
+fn strip_drive_root(mut path: String) -> String {
+    let mut chars = path.chars();
+    let rooted = chars.next() == Some('/');
+    let drive = chars.next().is_some_and(|c| c.is_ascii_alphabetic());
+    let colon = chars.next() == Some(':');
+    // A drive prefix is the whole path or is followed by a separator. `/C:x`
+    // is an ordinary relative-looking name, not a drive.
+    let bounded = matches!(chars.next(), None | Some('/'));
+    if rooted && drive && colon && bounded {
+        path.remove(0);
+    }
+    path
+}
+
+/// Decode RFC 3986 `%HH` sequences byte-wise. Anything that is not a valid
+/// triplet passes through verbatim, and malformed UTF-8 at the end of decoding
+/// degrades lossily rather than failing the finding. checkstyle encodes only
+/// the space and the quote, so a literal `%20` *in* a filename is ambiguous
+/// with an encoded one at the source; decoding is the better wrong there,
+/// because spaces in paths are common and `%20` in a name is not.
+fn percent_decode(text: &str) -> String {
+    if !text.contains('%') {
+        return text.to_owned();
+    }
+    let bytes = text.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let triplet = match bytes.get(i..i + 3) {
+            // `hi * 16 + lo`, not `hi << 4 | lo`: the two nibbles never share
+            // a set bit, so `|` and `^` agree on every reachable input and the
+            // mutation gate cannot observe the difference.
+            Some(&[b'%', hi, lo]) => hex_value(hi)
+                .zip(hex_value(lo))
+                .map(|(hi, lo)| hi * 16 + lo),
+            _ => None,
+        };
+        match triplet {
+            Some(byte) => {
+                decoded.push(byte);
+                i += 3;
+            }
+            None => {
+                decoded.push(bytes[i]);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    (byte as char).to_digit(16).map(|d| d as u8)
+}

--- a/src/languages/spec.rs
+++ b/src/languages/spec.rs
@@ -28,6 +28,8 @@ pub const DEFAULT_TOOL_TIMEOUT_SECS: u64 = 120;
 ///         into this tool". A tool with none of them present is skipped: its
 ///         defaults are not the project's chosen style, so running it anyway
 ///         would invent findings the project never asked for.
+///     config_flag: Flag that hands the discovered config file to the tool,
+///         for the checkers that will not look for it themselves.
 ///     output_format: How to parse the tool's diagnostics into findings.
 ///     diagnostics_stream: Which stream carries them. `go vet` writes to
 ///         stderr, so reading only stdout would report every Go file clean.
@@ -46,6 +48,15 @@ pub struct ToolSpec {
     /// project's chosen style, so running it anyway would invent findings the
     /// project never asked for.
     pub config_files: &'static [&'static str],
+    /// Flag that hands the discovered config file to the tool, e.g. `"-c"`.
+    ///
+    /// Most checkers find their own config: ruff reads `pyproject.toml` out of
+    /// the working directory without being told. The JVM linters do not.
+    /// `checkstyle` run bare exits 1 with "Must specify a config XML", so
+    /// without this it could not run at all. When set, the config path
+    /// `config_files` already discovered is appended as
+    /// `[config_flag, <path>]` ahead of the file arguments.
+    pub config_flag: Option<&'static str>,
     /// How to parse the tool's diagnostics into findings.
     pub output_format: &'static str,
     /// Which stream carries them. `go vet` writes to stderr, so reading only
@@ -82,6 +93,7 @@ impl Default for ToolSpec {
             command: &[],
             local_paths: &[],
             config_files: &[],
+            config_flag: None,
             output_format: "json",
             diagnostics_stream: "stdout",
             timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,


### PR DESCRIPTION
## Summary

- Register Java, Kotlin, Scala and Groovy. A repository of `.java` files previously reported "No source files drep recognises were found here" and `drep check` exited 0 having sent nothing to the model; unknown extensions were dropped at language grouping ahead of both halves.
- Java gets checkstyle, Kotlin gets ktlint. Scala and Groovy ship with no deterministic tool because scalafmt, scalafix and CodeNarc are build plugins rather than CLIs drep can invoke; their entries serve the semantic half. `.gradle` counts as Groovy and `.kts` as Kotlin, which covers `build.gradle.kts`.
- Add `ToolSpec::config_flag` for a checker that will not find its own config: checkstyle exits 1 with "Must specify a config XML" bare, so the discovered ruleset is appended as `-c <path>` ahead of the file arguments. Every pre-existing tool passes `None` and its argv is byte-identical.
- Add `sarif` and `ktlint` output parsers. SARIF is written against the 2.1.0 spec, strips the `file:` URI scheme and percent-decodes the path (checkstyle's SarifLogger encodes space and quote as `%20`/`%22`), so findings match the files drep was asked to check. ktlint gets its own format because its JSON reporter is eslint-shaped with different keys throughout; its sarif reporter binds `%SRCROOT%` to the process home and its relative URIs resolve to nothing drep checked (verified against ktlint 1.8.0). `--log-level=none` is load-bearing because ktlint writes logging to stdout ahead of the JSON.
- Review-fix round: pin SARIF note/none levels to Info with a discriminating test (a cargo-mutants survivor), drop `out` from the JVM vendored dirs because `is_ignored_dir` consults the union across languages and the entry skipped checked-in `out/` trees in non-JVM repositories, and document the ktlint `.editorconfig` opt-in trade-off in the README.
- Align mutation-offload docs with cc3a3cc: the default host is Legion (192.168.68.72). cargo-mutants was missing there; 27.1.0 installed and the default path verified end to end.

## Validation

- `cargo fmt --all`, `cargo clippy --all-targets --all-features`, `drep lint-docs --fail-on error`: clean
- `cargo test --all-targets --all-features`: 1,168 tests passed
- Scoped mutation sweep on Legion with the default configuration: 33 mutants, 26 caught, 0 missed, 1 timeout (detection), 6 unviable (non-compiling Default replacements)
- ktlint 1.8.0 container fixture: JSON reporter shape and absolute paths confirmed, stdout log pollution confirmed, nested `.editorconfig` verified to resolve upward from the file path regardless of the working directory
- End to end against a real Java repository: doctor reported 200 Java and 4 Groovy files; `drep check --diff` sent 8 changed Java files to the model where it previously analyzed none; against a fixture repo with a checkstyle ruleset and an `.editorconfig`, both tools run and findings arrive with the right file, line, column and rule
- Pre-push semantic review: clean